### PR TITLE
Refactoring for grunt-codacy

### DIFF
--- a/bin/codacy-coverage.js
+++ b/bin/codacy-coverage.js
@@ -15,7 +15,7 @@
     });
 
     program
-        .version('1.0.4')
+        .version(require('../package').version)
         .usage('[options]')
         .option('-f, --format [value]', 'Coverage input format')
         .option('-t, --token [value]', 'Codacy Project API Token')

--- a/bin/codacy-coverage.js
+++ b/bin/codacy-coverage.js
@@ -51,7 +51,12 @@
             debug: program.debug
         };
 
-        return lib.handleInput(input, opts);
+        return lib.handleInput(input, opts).then(function () {
+            loggerImpl.debug('Successfully sent coverage');
+        }, function (err) {
+            loggerImpl.error('Error sending coverage');
+            loggerImpl.error(err);
+        });
     });
 
 }(require('commander'), require('../lib/logger'), require('util'), require('../index')));

--- a/bin/codacy-coverage.js
+++ b/bin/codacy-coverage.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-(function (program, logger, util, lib, getGitData, Q) {
+(function (program, logger, util, lib) {
     'use strict';
     process.stdin.resume();
     process.stdin.setEncoding('utf8');
@@ -41,30 +41,17 @@
             return;
         }
 
-        var token = program.token || process.env.CODACY_REPO_TOKEN,
-            commitId = program.commit,
-            format = program.format || 'lcov',
-            pathPrefix = program.prefix || '';
+        var opts = {
+            endpoint: program.endpoint,
+            token: program.token,
+            commitId: program.commit,
+            format: program.format,
+            pathPrefix: program.prefix,
+            verbose: program.verbose,
+            debug: program.debug
+        };
 
-        if (!token) {
-            return loggerImpl.error(new Error('Token is required'));
-        }
-
-        // Parse the coverage data for the given format and retrieve the commit id if we don't have it.
-        return Q.all([lib.getParser(format).parse(pathPrefix, input), getGitData.getCommitId(commitId)]).spread(function (parsedCoverage, commitId) {
-            // Now that we've parse the coverage data to the correct format, send it to Codacy.
-            loggerImpl.trace(parsedCoverage);
-            lib.reporter({
-                endpoint: program.endpoint
-            }).sendCoverage(token, commitId, parsedCoverage).then(function () {
-                loggerImpl.debug('Successfully sent coverage');
-            }, function (err) {
-                loggerImpl.error('Error sending coverage');
-                loggerImpl.error(err);
-            });
-        }, function (err) {
-            loggerImpl.error(err);
-        });
+        return lib.handleInput(input, opts);
     });
 
-}(require('commander'), require('../lib/logger'), require('util'), require('../index'), require('../lib/getGitData'), require('q')));
+}(require('commander'), require('../lib/logger'), require('util'), require('../index')));

--- a/index.js
+++ b/index.js
@@ -1,8 +1,9 @@
-(function (parser, reporter, getGitData) {
+(function (parser, reporter, getGitData, handleInput) {
     'use strict';
     module.exports = {
         getParser: parser.getParser,
         reporter: reporter,
-        getGitData: getGitData
+        getGitData: getGitData,
+        handleInput: handleInput
     };
-}(require('./lib/coverageParser'), require('./lib/reporter'), require('./lib/getGitData')));
+}(require('./lib/coverageParser'), require('./lib/reporter'), require('./lib/getGitData'), require('./lib/handleInput')));

--- a/lib/handleInput.js
+++ b/lib/handleInput.js
@@ -24,16 +24,10 @@
         return Q.all([parser.getParser(format).parse(pathPrefix, input), getGitData.getCommitId(commitId)]).spread(function (parsedCoverage, commitId) {
             // Now that we've parse the coverage data to the correct format, send it to Codacy.
             loggerImpl.trace(parsedCoverage);
-            reporter({
+            loggerImpl.debug('Sending coverage');
+            return reporter({
                 endpoint: opts.endpoint
-            }).sendCoverage(token, commitId, parsedCoverage).then(function () {
-                loggerImpl.debug('Successfully sent coverage');
-            }, function (err) {
-                loggerImpl.error('Error sending coverage');
-                loggerImpl.error(err);
-            });
-        }, function (err) {
-            loggerImpl.error(err);
+            }).sendCoverage(token, commitId, parsedCoverage);
         });
     };
 }(require('./coverageParser'), require('./reporter'), require('./getGitData'), require('./logger'), require('q')));

--- a/lib/handleInput.js
+++ b/lib/handleInput.js
@@ -15,7 +15,9 @@
         });
 
         if (!token) {
-            return loggerImpl.error(new Error('Token is required'));
+            var err = new Error('Token is required');
+            loggerImpl.error(err);
+            return Q.reject(err);
         }
 
         // Parse the coverage data for the given format and retrieve the commit id if we don't have it.

--- a/lib/handleInput.js
+++ b/lib/handleInput.js
@@ -1,0 +1,37 @@
+(function (parser, reporter, getGitData, logger, Q) {
+    'use strict';
+    module.exports = function (input, opts) {
+        opts = opts || {};
+
+        var token = opts.token || process.env.CODACY_REPO_TOKEN,
+            commitId = opts.commit,
+            format = opts.format || 'lcov',
+            pathPrefix = opts.prefix || '',
+            loggerImpl;
+
+        loggerImpl = logger({
+            verbose: opts.verbose,
+            debug: opts.debug
+        });
+
+        if (!token) {
+            return loggerImpl.error(new Error('Token is required'));
+        }
+
+        // Parse the coverage data for the given format and retrieve the commit id if we don't have it.
+        return Q.all([parser.getParser(format).parse(pathPrefix, input), getGitData.getCommitId(commitId)]).spread(function (parsedCoverage, commitId) {
+            // Now that we've parse the coverage data to the correct format, send it to Codacy.
+            loggerImpl.trace(parsedCoverage);
+            reporter({
+                endpoint: opts.endpoint
+            }).sendCoverage(token, commitId, parsedCoverage).then(function () {
+                loggerImpl.debug('Successfully sent coverage');
+            }, function (err) {
+                loggerImpl.error('Error sending coverage');
+                loggerImpl.error(err);
+            });
+        }, function (err) {
+            loggerImpl.error(err);
+        });
+    };
+}(require('./coverageParser'), require('./reporter'), require('./getGitData'), require('./logger'), require('q')));

--- a/test/handleInput.js
+++ b/test/handleInput.js
@@ -1,0 +1,15 @@
+(function (chai, handleInput) {
+    'use strict';
+
+    var expect = chai.expect;
+    chai.use(require('chai-as-promised'));
+    chai.use(require('dirty-chai'));
+    chai.config.includeStack = true;
+
+    describe('Handle Input', function () {
+        it('should return a promise', function () {
+            return expect(handleInput()).to.eventually.be.rejected;
+        });
+    });
+
+}(require('chai'), require('../lib/handleInput')));

--- a/test/lcov.js
+++ b/test/lcov.js
@@ -1,7 +1,8 @@
 (function (Joi, chai, Q, fs, parser) {
     'use strict';
 
-    var expect = chai.expect,
+    var path = require('path'),
+        expect = chai.expect,
         lcovData = fs.readFileSync(__dirname + '/mock/lcov.info').toString(),
         noStatsLcovData = fs.readFileSync(__dirname + '/mock/no-lines.info').toString(),
         nadaLcovData = fs.readFileSync(__dirname + '/mock/nada.info').toString();
@@ -18,7 +19,7 @@
                         total: 92,
                         fileReports: [
                             {
-                                filename: 'lib/reporter.js',
+                                filename: path.normalize('lib/reporter.js'),
                                 coverage: {
                                     1: 1,
                                     25: 1,
@@ -53,13 +54,13 @@
                 });
         });
         it('should be able to parse lcov data with path prefix', function () {
-            return expect(parser.getParser('lcov').parse('my-project/', lcovData))
+            return expect(parser.getParser('lcov').parse(path.normalize('my-project/'), lcovData))
                 .to.eventually.satisfy(function (data) {
                     expect(data).to.deep.equal({
                         total: 92,
                         fileReports: [
                             {
-                                filename: 'my-project/lib/reporter.js',
+                                filename: path.normalize('my-project/lib/reporter.js'),
                                 coverage: {
                                     1: 1,
                                     25: 1,
@@ -100,7 +101,7 @@
                         total: null,
                         fileReports: [
                             {
-                                filename: 'lib/reporter.js',
+                                filename: path.normalize('lib/reporter.js'),
                                 coverage: {},
                                 total: null
                             }


### PR DESCRIPTION
Major:
- I'm refactoring this code a bit to be more in line with node-coveralls. It now exposes a `handleInput` interface on the main export. This takes the input data and options just like the command line version. I've changed the command line version to pass through to this same interface. These modifications allow to create grunt and gulp plugins more easily.

Minor:
- App version is no longer hardcoded in two places. Command line retrieves it from `package.json`.
- Fixed tests for Windows support. Just some path normalisation for the reversed directory delimiters.