### PR TITLE
Move to Bluebird for Promises

### DIFF
--- a/lib/getGitData.js
+++ b/lib/getGitData.js
@@ -1,12 +1,11 @@
-(function (logger, exec, Q) {
+(function (logger, exec, Promise) {
     'use strict';
     module.exports = {
         getCommitId: function (commitId) {
-            var deferred = Q.defer();
-            process.nextTick(function () {
+            return new Promise(function (resolve, reject) {
                 if (commitId) {
                     logger.debug('Provided Commit Id: ' + commitId);
-                    return deferred.resolve(commitId);
+                    return resolve(commitId);
                 }
 
                 var gitCommit = process.env.CODACY_GIT_COMMIT ||
@@ -19,19 +18,18 @@
 
                 if (gitCommit) {
                     logger.debug('Received Commit Id: ' + gitCommit);
-                    return deferred.resolve(gitCommit);
+                    return resolve(gitCommit);
                 }
 
                 exec('git rev-parse HEAD', function (err, commitId) {
                     if (err) {
-                        return deferred.reject(err);
+                        return reject(err);
                     }
                     commitId = commitId.trim();
                     logger.debug('Got Commit Id: ' + commitId);
-                    deferred.resolve(commitId);
+                    resolve(commitId);
                 });
             });
-            return deferred.promise;
         }
     };
-}(require('./logger')(), require('child_process').exec, require('q')));
+}(require('./logger')(), require('child_process').exec, require('bluebird')));

--- a/lib/handleInput.js
+++ b/lib/handleInput.js
@@ -1,4 +1,4 @@
-(function (parser, reporter, getGitData, logger, Q) {
+(function (parser, reporter, getGitData, logger, Promise) {
     'use strict';
     module.exports = function (input, opts) {
         opts = opts || {};
@@ -16,12 +16,11 @@
 
         if (!token) {
             var err = new Error('Token is required');
-            loggerImpl.error(err);
-            return Q.reject(err);
+            return Promise.reject(err);
         }
 
         // Parse the coverage data for the given format and retrieve the commit id if we don't have it.
-        return Q.all([parser.getParser(format).parse(pathPrefix, input), getGitData.getCommitId(commitId)]).spread(function (parsedCoverage, commitId) {
+        return Promise.all([parser.getParser(format).parse(pathPrefix, input), getGitData.getCommitId(commitId)]).spread(function (parsedCoverage, commitId) {
             // Now that we've parse the coverage data to the correct format, send it to Codacy.
             loggerImpl.trace(parsedCoverage);
             loggerImpl.debug('Sending coverage');
@@ -30,4 +29,4 @@
             }).sendCoverage(token, commitId, parsedCoverage);
         });
     };
-}(require('./coverageParser'), require('./reporter'), require('./getGitData'), require('./logger'), require('q')));
+}(require('./coverageParser'), require('./reporter'), require('./getGitData'), require('./logger'), require('bluebird')));

--- a/lib/impl/lcov.js
+++ b/lib/impl/lcov.js
@@ -1,12 +1,11 @@
-(function (lcovParse, Q, Joi, logger, path) {
+(function (lcovParse, Promise, Joi, logger, path) {
     'use strict';
     var lcovStringValidation = Joi.string().required(),
         optionsValidation = Joi.object().keys().optional();
     module.exports = {
         parse: function parseLcov(pathPrefix, lcovString, options) {
-            logger.debug('Parsing Lcov Data');
-            var deferred = Q.defer();
-            process.nextTick(function () {
+            return new Promise(function (resolve, reject) {
+                logger.debug('Parsing Lcov Data');
                 var validLcov = Joi.validate(lcovString, lcovStringValidation),
                     validOptions = Joi.validate(options, optionsValidation, {
                         stripUnknown: true
@@ -15,7 +14,7 @@
 
                 if (validationError) {
                     logger.error(validationError);
-                    return deferred.reject(validationError);
+                    return reject(validationError);
                 }
 
                 lcovParse(lcovString, function (err, data) {
@@ -23,7 +22,7 @@
                         err = new Error(err);
 
                         logger.error(err);
-                        return deferred.reject(err);
+                        return reject(err);
                     }
 
                     var result = {
@@ -65,10 +64,9 @@
 
                     logger.debug('Successfully Parsed Lcov Data');
 
-                    deferred.resolve(result);
+                    resolve(result);
                 });
             });
-            return deferred.promise;
         }
     };
-}(require('lcov-parse'), require('q'), require('joi'), require('../logger')(), require('path')));
+}(require('lcov-parse'), require('bluebird'), require('joi'), require('../logger')(), require('path')));

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -1,4 +1,4 @@
-(function (request, Joi, Q, util, logger) {
+(function (request, Joi, Promise, util, logger) {
     'use strict';
 
     var optionsValidation = Joi.object({
@@ -31,9 +31,7 @@
 
         return {
             sendCoverage: function sendCoverage(token, commitId, data) {
-                var deferred = Q.defer();
-
-                process.nextTick(function () {
+                return new Promise(function (resolve, reject) {
                     logger.trace(util.format('Sending Coverage for token [%s] and commitId [%s]', token, commitId));
                     var tokenValid = Joi.validate(token, tokenValidation),
                         commitIdValid = Joi.validate(commitId, commitIdValidation),
@@ -44,7 +42,7 @@
 
                     if (validationErr) {
                         logger.error(validationErr);
-                        return deferred.reject(validationErr);
+                        return reject(validationErr);
                     }
 
                     var url = endpoint.replace(':token', token).replace(':commitId', commitId);
@@ -59,18 +57,17 @@
                         if (res.statusCode !== 200) {
                             var err = new Error(util.format('Expected Status Code of 200, but got [%s]', res.statusCode));
                             logger.error(util.format('Status Code [%s] - Error [%j]', res.statusCode, res.error));
-                            return deferred.reject(err);
+                            return reject(err);
                         }
                         logger.debug('Successfully sent coverage data');
-                        deferred.resolve();
+                        resolve();
                     }, function (res) {
                         var err = new Error(util.format('Expected Successful Status Code, but got [%s]', res.statusCode));
                         logger.error(util.format('Status Code [%s] - Error [%j]', res.statusCode, res.error));
-                        deferred.reject(err);
+                        reject(err);
                     });
                 });
-                return deferred.promise;
             }
         };
     };
-}(require('request-promise'), require('joi'), require('q'), require('util'), require('./logger')()));
+}(require('request-promise'), require('joi'), require('bluebird'), require('util'), require('./logger')()));

--- a/package.json
+++ b/package.json
@@ -33,11 +33,11 @@
     "codacy-coverage": "./bin/codacy-coverage.js"
   },
   "dependencies": {
+    "bluebird": "^2.9.25",
     "commander": "^2.x",
     "joi": "^5.x",
     "lcov-parse": "0.x",
     "log-driver": "^1.x",
-    "q": "^1.x",
     "request-promise": "^0.x"
   },
   "devDependencies": {

--- a/test/cli.js
+++ b/test/cli.js
@@ -1,10 +1,7 @@
-(function (chai, Q, exec, Joi, parser, helper) {
+(function (exec, Joi, parser, helper) {
     'use strict';
 
-    var expect = chai.expect;
-    chai.use(require('chai-as-promised'));
-    chai.use(require('dirty-chai'));
-    chai.config.includeStack = true;
+    var expect = helper.chai.expect;
 
     describe('Command Line', function () {
         it('should be able to parse lcov data', function (done) {
@@ -60,4 +57,4 @@
             });
         });
     });
-}(require('chai'), require('q'), require('child_process').exec, require('joi'), require('../'), require('./helper')));
+}(require('child_process').exec, require('joi'), require('../'), require('./helper')));

--- a/test/coverageParser.js
+++ b/test/coverageParser.js
@@ -1,11 +1,8 @@
-(function (Joi, chai, Q, util, parser) {
+(function (util, parser, helper) {
     'use strict';
 
-    var expect = chai.expect,
+    var expect = helper.chai.expect,
         validFormats = ['lcov'];
-    chai.use(require('chai-as-promised'));
-    chai.use(require('dirty-chai'));
-    chai.config.includeStack = true;
 
     describe('Coverage Parser', function () {
         it('should receive an error when trying to use an unsupported format', function () {
@@ -31,4 +28,4 @@
             });
         });
     });
-}(require('joi'), require('chai'), require('q'), require('util'), require('../lib/coverageParser')));
+}(require('util'), require('../lib/coverageParser'), require('./helper')));

--- a/test/getGitData.js
+++ b/test/getGitData.js
@@ -1,11 +1,8 @@
-(function (Joi, chai, Q, util, getGitData) {
+(function (util, getGitData, helper) {
     'use strict';
 
-    var expect = chai.expect,
+    var expect = helper.chai.expect,
         actualTravisCommit = process.env.TRAVIS_COMMIT; // Store the commit id for the test, if we have it
-    chai.use(require('chai-as-promised'));
-    chai.use(require('dirty-chai'));
-    chai.config.includeStack = true;
 
     describe('Get Git Data', function () {
         beforeEach(function () {
@@ -58,4 +55,4 @@
             return expect(getGitData.getCommitId()).to.eventually.be.fulfilled;
         });
     });
-}(require('joi'), require('chai'), require('q'), require('util'), require('../lib/getGitData')));
+}(require('util'), require('../lib/getGitData'), require('./helper')));

--- a/test/handleInput.js
+++ b/test/handleInput.js
@@ -1,15 +1,12 @@
-(function (chai, handleInput) {
+(function (handleInput, helper) {
     'use strict';
 
-    var expect = chai.expect;
-    chai.use(require('chai-as-promised'));
-    chai.use(require('dirty-chai'));
-    chai.config.includeStack = true;
+    var expect = helper.chai.expect;
 
     describe('Handle Input', function () {
         it('should return a promise', function () {
-            return expect(handleInput()).to.eventually.be.rejected;
+            return expect(handleInput()).to.eventually.be.rejected();
         });
     });
 
-}(require('chai'), require('../lib/handleInput')));
+}(require('../lib/handleInput'), require('./helper')));

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,4 +1,4 @@
-(function (nock, chai, Q) {
+(function (nock, chai, Promise) {
     'use strict';
 
     var expect = chai.expect;
@@ -11,27 +11,22 @@
 
     //Setup mock for the Codacy API endpoint.
     function setupMockEndpoint(token, commitId, bodyValidator, statusCode) {
-        var deferred = Q.defer();
-        process.nextTick(function () {
-            try {
-                expect(token).to.be.ok();
-                expect(commitId).to.be.ok();
-                expect(bodyValidator).to.be.ok();
+        return new Promise(function (resolve) {
+            expect(token).to.be.ok();
+            expect(commitId).to.be.ok();
+            expect(bodyValidator).to.be.ok();
 
-                return deferred.resolve(nock('https://www.codacy.com')
-                    .post('/api/coverage/' + token + '/' + commitId, function (body) {
-                        var result = bodyValidator.validate(body);
-                        return result.error ? false : true;
-                    })
-                    .reply(statusCode || 200));
-            } catch (err) {
-                deferred.reject(err);
-            }
+            return resolve(nock('https://www.codacy.com')
+                .post('/api/coverage/' + token + '/' + commitId, function (body) {
+                    var result = bodyValidator.validate(body);
+                    return result.error ? false : true;
+                })
+                .reply(statusCode || 200));
         });
-        return deferred.promise;
     }
 
     module.exports = {
-        setupMockEndpoint: setupMockEndpoint
+        setupMockEndpoint: setupMockEndpoint,
+        chai: chai
     };
-}(require('nock'), require('chai'), require('q')));
+}(require('nock'), require('chai'), require('bluebird')));

--- a/test/lcov.js
+++ b/test/lcov.js
@@ -1,15 +1,11 @@
-(function (Joi, chai, Q, fs, parser) {
+(function (fs, parser, helper) {
     'use strict';
 
     var path = require('path'),
-        expect = chai.expect,
+        expect = helper.chai.expect,
         lcovData = fs.readFileSync(__dirname + '/mock/lcov.info').toString(),
         noStatsLcovData = fs.readFileSync(__dirname + '/mock/no-lines.info').toString(),
         nadaLcovData = fs.readFileSync(__dirname + '/mock/nada.info').toString();
-
-    chai.use(require('chai-as-promised'));
-    chai.use(require('dirty-chai'));
-    chai.config.includeStack = true;
 
     describe('Lcov Parser', function () {
         it('should be able to parse lcov data', function () {
@@ -127,4 +123,4 @@
                 });
         });
     });
-}(require('joi'), require('chai'), require('q'), require('fs'), require('../lib/coverageParser')));
+}(require('fs'), require('../lib/coverageParser'), require('./helper')));

--- a/test/logger.js
+++ b/test/logger.js
@@ -1,11 +1,8 @@
-(function (Joi, chai) {
+(function (helper) {
     'use strict';
 
-    var expect = chai.expect,
+    var expect = helper.chai.expect,
         logger;
-    chai.use(require('chai-as-promised'));
-    chai.use(require('dirty-chai'));
-    chai.config.includeStack = true;
 
     describe('Logger', function () {
         beforeEach(function () {
@@ -60,4 +57,4 @@
             expect(logger().level).to.equal('warn');
         });
     });
-}(require('joi'), require('chai')));
+}(require('./helper')));

--- a/test/reporter.js
+++ b/test/reporter.js
@@ -1,10 +1,7 @@
-(function (Joi, request, chai, Q, reporter, helper) {
+(function (Joi, request, reporter, helper) {
     'use strict';
 
-    var expect = chai.expect;
-    chai.use(require('chai-as-promised'));
-    chai.use(require('dirty-chai'));
-    chai.config.includeStack = true;
+    var expect = helper.chai.expect;
 
     describe('Codacy Reporter', function () {
         var bodyValidator,
@@ -90,4 +87,4 @@
         });
     });
 
-}(require('joi'), require('request-promise'), require('chai'), require('q'), require('../lib/reporter'), require('./helper')));
+}(require('joi'), require('request-promise'), require('../lib/reporter'), require('./helper')));


### PR DESCRIPTION
This PR moves the Promise library over to Bluebird from Q in favor of their more performant promises. Additionally, Bluebird provides useful helper functions for promises as well as handles using promises for synchronous code more gracefully (through a Promise constructor with a try/catcher instead of a "defer"). This way unhandled exceptions are not accidentally swallowed by the library and instead they will bubble up the Promise chain.