### PR TITLE
update environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This script ( `bin/codacy-coverage.js` ) can take standard input from any tool t
 Once your app is instrumented for coverage, and building, you need to pipe the lcov output to `./node_modules/codacy-coverage/bin/codacy-coverage.js`.
 
 You'll need to provide the Report token from Codacy via an environment variable:
-* CODACY_REPO_TOKEN (the secret repo token from Codacy.com)
+* CODACY_PROJECT_TOKEN (the secret repo token from Codacy.com)
 
 ### [Mocha](http://visionmedia.github.io/mocha/) + [Blanket.js](https://github.com/alex-seville/blanket)
 - Install [blanket.js](http://blanketjs.org/)

--- a/lib/handleInput.js
+++ b/lib/handleInput.js
@@ -3,7 +3,7 @@
     module.exports = function (input, opts) {
         opts = opts || {};
 
-        var token = opts.token || process.env.CODACY_REPO_TOKEN;
+        var token = opts.token || process.env.CODACY_PROJECT_TOKEN || process.env.CODACY_REPO_TOKEN;
         var commit = opts.commit;
         var format = opts.format || 'lcov';
         var pathPrefix = opts.prefix || '';

--- a/test/handleInput.js
+++ b/test/handleInput.js
@@ -3,12 +3,12 @@
 
     var expect = helper.chai.expect;
     var lcovData = fs.readFileSync(__dirname + '/mock/lcov.info').toString();
-    var originalCodacyToken = process.env.CODACY_REPO_TOKEN;
+    var originalCodacyToken = process.env.CODACY_PROJECT_TOKEN || process.env.CODACY_REPO_TOKEN;
 
     describe('Handle Input', function () {
         beforeEach(function () {
             helper.clearEnvironmentVariables();
-            process.env.CODACY_REPO_TOKEN = originalCodacyToken;
+            process.env.CODACY_PROJECT_TOKEN = originalCodacyToken;
         });
         it('should be able to use the mock end-point', function () {
             var bodyValidator = Joi.object({
@@ -138,7 +138,7 @@
                 });
         });
         it('shouldn\'t be able to send coverage with invalid input', function () {
-            process.env.CODACY_REPO_TOKEN = '';
+            process.env.CODACY_PROJECT_TOKEN = '';
             return expect(handleInput()).to.eventually.be.rejectedWith(Error, 'Token is required');
         });
     });


### PR DESCRIPTION
So, there seems to be a disagreement between this package and the official documentation on which environment variable should be used.

The docs say:

![docs](http://content.screencast.com/users/chiller/folders/Jing/media/7ac34527-92d5-48a5-b7c3-1282dbd1ca08/00000195.png)

But this package uses `CODACY_REPO_TOKEN`.

Regardless, this PR supports both.  :stuck_out_tongue: 