### PR TITLE
Use correct license property in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,12 +22,7 @@
     "url": "https://github.com/DavidTPate"
   },
   "contributors": [],
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://www.opensource.org/licenses/MIT"
-    }
-  ],
+  "license": "MIT",
   "main": "index.js",
   "bin": {
     "codacy-coverage": "./bin/codacy-coverage.js"


### PR DESCRIPTION
This [license property in package.json](https://docs.npmjs.com/files/package.json#license) should be named `license` and be a SPDX license expression syntax formated string.

The old style of having an array of licenses are now deprecated by npm and the rcommedations it to use SPDX expressions like this:

```json
{ "license": "ISC" }

{ "license": "(MIT OR Apache-2.0)" }
```