### PR TITLE
Add Buildkite environment variable for commit ID

### DIFF
--- a/lib/getGitData.js
+++ b/lib/getGitData.js
@@ -14,7 +14,8 @@
                     process.env.GIT_COMMIT ||
                     process.env.CIRCLE_SHA1 ||
                     process.env.CI_COMMIT_ID ||
-                    process.env.WERCKER_GIT_COMMIT;
+                    process.env.WERCKER_GIT_COMMIT ||
+                    process.env.BUILDKITE_COMMIT;
 
                 if (gitCommit) {
                     logger.debug('Received Commit Id: ' + gitCommit);

--- a/test/getGitData.js
+++ b/test/getGitData.js
@@ -39,6 +39,10 @@
             process.env.WERCKER_GIT_COMMIT = '5232';
             return expect(getGitData.getCommitId()).to.eventually.equal('5232');
         });
+        it('should be able to get the commit id from the Buildkite environment variable', function () {
+            process.env.BUILDKITE_COMMIT = '47326';
+            return expect(getGitData.getCommitId()).to.eventually.equal('47326');
+        });
         it('should be able to get the commit id from Git', function () {
             // If we are currently running on Travis, we should be able to use the commit id environment variable
             // to check the git commit id method with actual git. But we can't do this for Pull Requests because

--- a/test/helper.js
+++ b/test/helper.js
@@ -73,6 +73,7 @@
             process.env.CIRCLE_SHA1 = '';
             process.env.CI_COMMIT_ID = '';
             process.env.WERCKER_GIT_COMMIT = '';
+            process.env.BUILDKITE_COMMIT = '';
         }
     };
 }(require('nock'), require('chai'), require('bluebird')));


### PR DESCRIPTION
Add the [Buildkite](https://buildkite.com) commit ID variable
so that this will automatically work when running on Buildkite.

Ref: [Buildkite Environment Variables](https://buildkite.com/docs/builds/environment-variables)