### PR TITLE
Fixes inaccurate documentation for integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ As an alternative to the Project API token you can also send coverage using your
 
 ```json
 "scripts": {
-  "test-with-coverage": "cat ./coverage/lcov.info | codacy-coverage --accountToken <account-token> --username <username> --projectName <project-name>"
+  "test-with-coverage": "cat ./coverage/lcov.info | codacy-coverage --token <account-token> --username <username> --projectName <project-name>"
 }
 ```
 


### PR DESCRIPTION
Using --accountToken gives a 404 error, using --token works.